### PR TITLE
Fixes XDN-16041 - ReactFrontStore demo breaks with uBlock Origin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-storefront-analytics",
-  "version": "1.0.2",
+  "version": "1.1.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-storefront-analytics",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "license": "Apache-2.0",
   "repository": "https://github.com/storefront-foundation/react-storefront-analytics",
   "bugs": "https://github.com/storefront-foundation/react-storefront-analytics/issues",

--- a/src/firebase/FirebasePerformanceMonitoring.js
+++ b/src/firebase/FirebasePerformanceMonitoring.js
@@ -31,8 +31,12 @@ export default function FirebasePerformanceMonitoring({
   useEffect(() => {
     if (config) {
       Router.events.on('routeChangeStart', () => {
-        context.trace = window.firebasePerf.trace(clientSideNavigationTraceName)
-        context.trace.start() // the trace will be ended by FirebaseNavigationTrace
+        if (window.firebasePerf) {
+          // It's possible for Firebase to be blocked by browser extensinos such as uBlock Origin,
+          // so we check to make sure it's defined first.
+          context.trace = window.firebasePerf.trace(clientSideNavigationTraceName)
+          context.trace.start() // the trace will be ended by FirebaseNavigationTrace
+        }
       })
     }
   }, [config])
@@ -55,8 +59,10 @@ export default function FirebasePerformanceMonitoring({
           a.async=1;a.src=f;var s=document.getElementsByTagName('script')[0];
           s.parentNode.insertBefore(a,s);}load(sa);
           window.addEventListener('load',function(){ 
-            window.firebasePerf = firebase.initializeApp(fbc).performance(); 
-            __rsfFirebaseSendPerformanceMetrics(window.firebasePerf)
+            if (window.firebase) {
+              window.firebasePerf = firebase.initializeApp(fbc).performance(); 
+              __rsfFirebaseSendPerformanceMetrics(window.firebasePerf)
+            }
           });
           })(${JSON.stringify(firebaseSdkUrl)}, ${JSON.stringify(config)});`,
           }}


### PR DESCRIPTION
The root cause was Firebase being blocked by uBlock origin. Firebase is used to track performance during client-side navigation.

Here's a deployment with this fix on staging:
https://react-storefront-react-storefront-starter-app-staging.layer0-limelight.link